### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # jupyter-ml-tensorflow and jupyter-ml-pytorch
 
+This repository contains the source code for two o²S²PARC Services: jupyyter-ml-tensorflow and jupyter-ml-pytorch
 
 Building the docker images:
 


### PR DESCRIPTION
update readme to trigger a CI run and unblock the publisher CI on Gitlab.

For unblocking the publisher CI, it is OK that this CI is red. However, since it fails to build the image, we'll need at some point to publish a new version.