### PR TITLE
Making docker build run again

### DIFF
--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -12,11 +12,11 @@ jobs:
         uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
         with:
           args: ooil --version
-      - name: Assemble docker-compose spec
+      - name: Assemble docker compose spec
         uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
         with:
           args: ooil compose
       - name: Build all images if multiple
         uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
         with:
-          args: docker-compose build
+          args: docker compose build

--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout repo content
         uses: actions/checkout@v2
       - name: ooil version
-        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
         with:
           args: ooil --version
       - name: Assemble docker compose spec
-        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
         with:
           args: ooil compose
       - name: Build all images if multiple
-        uses: docker://itisfoundation/ci-service-integration-library:v1.0.1-dev-31
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
         with:
           args: docker compose build

--- a/.osparc/jupyter-ml-pytorch/docker-compose.overwrite.yml
+++ b/.osparc/jupyter-ml-pytorch/docker-compose.overwrite.yml
@@ -1,5 +1,7 @@
 services:
   jupyter-ml-pytorch:
+    depends_on: 
+      - common
     build:
       context: ./jupyter-ml-pytorch
       dockerfile: Dockerfile

--- a/.osparc/jupyter-ml-tensorflow/docker-compose.overwrite.yml
+++ b/.osparc/jupyter-ml-tensorflow/docker-compose.overwrite.yml
@@ -1,5 +1,7 @@
 services:
   jupyter-ml-tensorflow:
+    depends_on: 
+      - common
     build:
       context: ./jupyter-ml-tensorflow
       dockerfile: Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ define _bumpversion
 	# upgrades as $(subst $(1),,$@) version, commits and tags
 	@docker run -it --rm -v $(PWD):/ml-lab \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v1.0.1-dev-31 \
+		itisfoundation/ci-service-integration-library:v2.0.9-dev \
 		sh -c "cd /ml-lab && bump2version --verbose --list --config-file $(1) $(subst $(2),,$@)"
 endef
 
@@ -30,7 +30,7 @@ version-pytorch-patch version-pytorch-minor version-pytorch-major: .bumpversion-
 compose-spec: ## runs ooil to assemble the docker-compose.yml file
 	@docker run -it --rm -v $(PWD):/ml-lab \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v1.0.1-dev-31 \
+		itisfoundation/ci-service-integration-library:v2.0.9-dev \
 		sh -c "cd /ml-lab && ooil compose"
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,19 @@ compose-spec: ## runs ooil to assemble the docker-compose.yml file
 
 .PHONY: build
 build: compose-spec ## build docker images
-	docker-compose build
+	docker compose build
 
 .PHONY: run-pytorch-local
 run-pytorch-local: ## runs pytorch image with local configuration
 	IMAGE_TO_RUN=${IMAGE_PYTORCH} \
 	TAG_TO_RUN=${TAG_PYTORCH} \
-	docker-compose --file docker-compose-local.yml up
+	docker compose --file docker-compose-local.yml up
 
 .PHONY: run-tensorflow-local
 run-tensorflow-local: ## runs tensorflow image with local configuration
 	IMAGE_TO_RUN=${IMAGE_TENSORFLOW} \
 	TAG_TO_RUN=${TAG_TENSORFLOW} \
-	docker-compose --file docker-compose-local.yml up
+	docker compose --file docker-compose-local.yml up
 
 publish-local:  ## push to local throw away registry to test integration
 	@docker tag simcore/services/dynamic/${IMAGE_PYTORCH}:${TAG_PYTORCH} registry:5000/simcore/services/dynamic/${IMAGE_PYTORCH}:${TAG_PYTORCH}

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.1-cudnn8-runtime-ubuntu18.04 as ml-base
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu18.04 AS ml-base
 
 LABEL maintainer="Andrei Neagu <neagu@speag.swiss>"
 

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -62,60 +62,36 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
 
 USER $NB_UID
 WORKDIR $HOME
-ARG PYTHON_VERSION=default
+ARG PYTHON_VERSION=3.7
 
 # Setup work directory for backward-compatibility
 RUN mkdir /home/$NB_USER/work && \
     fix-permissions /home/$NB_USER
 
-# Install conda as jovyan and check the md5 sum provided on the download site
-ENV MINICONDA_VERSION=4.8.2 \
-    MINICONDA_MD5=87e77f097f6ebb5127c77662dfc3165e \
-    CONDA_VERSION=4.8.2
-
+ENV MAMBAFORGE_VERSION=23.1.0-1
 RUN cd /tmp && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "${MINICONDA_MD5} *Miniconda3-py37_${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
-    /bin/bash Miniconda3-py37_${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
-    rm Miniconda3-py37_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
-    conda config --system --prepend channels conda-forge && \
-    conda config --system --set auto_update_conda false && \
-    conda config --system --set show_channel_urls true && \
-    conda config --system --set channel_priority strict && \
-    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
-    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
-    conda install --quiet --yes conda && \
-    conda install --quiet --yes pip && \
-    conda update --all --quiet --yes && \
-    conda clean --all -f -y && \
-    rm -rf /home/$NB_USER/.cache/yarn && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
-
-# Install Tini
-RUN conda install --quiet --yes 'tini=0.18.0' && \
-    conda list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
-    conda clean --all -f -y && \
-    fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
-
-# Install Jupyter Notebook, Lab, and Hub
-# Generate a notebook server config
-# Cleanup temporary files
-# Correct permissions
-# Do all this in a single RUN command to avoid duplicating all of the
-# files across image layers when the permissions change
-RUN conda install --quiet --yes \
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh" && \
+    /bin/bash Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Mambaforge-${MAMBAFORGE_VERSION}-Linux-x86_64.sh && \
+    mamba config --system --prepend channels conda-forge && \
+    mamba config --system --set auto_update_conda false && \
+    mamba config --system --set show_channel_urls true && \
+    mamba config --system --set channel_priority strict && \
+    mamba config --system --set repodata_threads 5 && \
+    mamba install --yes python=$PYTHON_VERSION && \
+    mamba list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
+    mamba list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
+    mamba install --yes \
+    pip \
+    'tini=0.18.0' \
     'notebook=6.4.8' \
     'jupyterhub=2.1.1' \
     'jupyterlab=3.2.9' && \
-    conda clean --all -f -y && \
+    mamba clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
     rm -rf /home/$NB_USER/.cache/yarn && \
-    fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
 # Copy local files as late as possible to avoid cache busting
@@ -212,14 +188,14 @@ USER $NB_UID
 # jupyter customizations
 # https://github.com/jupyterlab/jupyterlab-git/releases
 #
-RUN conda install --quiet --yes \
+RUN mamba install --quiet --yes \
     jupyterlab-git \
     # https://github.com/jupyterlab/jupyterlab-latex/
     jupyterlab_latex \
-    && conda install -c conda-forge \
+    && mamba install -c conda-forge \
     ipyevents==2.0.1 \
     ipympl==0.8.8 \
-    && conda clean --all -f -y \
+    && mamba clean --all -f -y \
     && jupyter lab build -y \
     && jupyter lab clean -y \
     && npm cache clean --force \
@@ -273,10 +249,10 @@ USER $NB_USER
 RUN git clone https://github.com/pyenv/pyenv.git ${HOME}/.pyenv && \
     git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
     pyenv install ${PYTHON_VERSION} && \
-    pyenv virtualenv 3.9.12 lab-venv && \
+    pyenv virtualenv ${PYTHON_VERSION} lab-venv && \
     ${HOME}/.pyenv/versions/lab-venv/bin/python --version && \
     ${HOME}/.pyenv/versions/lab-venv/bin/pip install --upgrade pip ipykernel && \
-    ${HOME}/.pyenv/versions/lab-venv/bin/python -m ipykernel install --user --name kpy39 --display-name "Python (3.9.12)" && \
+    ${HOME}/.pyenv/versions/lab-venv/bin/python -m ipykernel install --user --name kpy39 --display-name "Python (${PYTHON_VERSION})" && \
     echo y | jupyter kernelspec uninstall python3
 
 USER root

--- a/jupyter-ml-pytorch/Dockerfile
+++ b/jupyter-ml-pytorch/Dockerfile
@@ -1,4 +1,4 @@
-FROM simcore/services/dynamic/common:0.0.0 as service-base
+FROM simcore/services/dynamic/common:0.0.0 AS service-base
 
 LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 

--- a/jupyter-ml-pytorch/requirements.txt
+++ b/jupyter-ml-pytorch/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 torch==1.11.0+cu113
 torchaudio==0.11.0+cu113
 torchvision==0.12.0+cu113

--- a/jupyter-ml-tensorflow/Dockerfile
+++ b/jupyter-ml-tensorflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM simcore/services/dynamic/common:0.0.0 as service-base
+FROM simcore/services/dynamic/common:0.0.0 AS service-base
 
 LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 

--- a/jupyter-ml-tensorflow/requirements.txt
+++ b/jupyter-ml-tensorflow/requirements.txt
@@ -1,1 +1,2 @@
+numpy<2
 tensorflow-gpu==2.9.0


### PR DESCRIPTION
Despite of the changes, this brings down the build time by quite a lot while also keeping compatibility with the old installation.
`tensorflow` and `pytorch` still run with CUDA support when I. have tested the built images locally.

- using docker compose 2.x.x
- upgraded to ci-service-integration-library v2.0.9-dev
- cuda image bumped to 11.2.2 from 11.2.1
- docker syntax fixes
- replaced conda with mamba
- pinned numpy<2
- unified mamba install steps