### PR TITLE
Fix missing `=` in `docker-compose.yml` envs

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -5,10 +5,10 @@ services:
     ports:
       - 8888:8888
     environment:
+      - DY_BOOT_OPTION_BOOT_MODE=0
+      - DY_SIDECAR_PATH=/home/jovyan/work/workspace
       - DY_SIDECAR_PATH_INPUTS=/tmp/inputs
       - DY_SIDECAR_PATH_OUTPUTS=/tmp/outputs
-      - DY_BOOT_OPTION_BOOT_MODE=0
-      - DY_SIDECAR_PATH/home/jovyan/work/workspace
     volumes:
       - ${PWD}/validation/workspace:/home/jovyan/work/workspace
       - ${PWD}/validation/inputs:/tmp/inputs


### PR DESCRIPTION
Fixed a missing `=` in `docker-compose.yml`.