### PR TITLE
Upgraded tensorflow pytorch to latest versions

### DIFF
--- a/.bumpversion-pytorch.cfg
+++ b/.bumpversion-pytorch.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.bumpversion-pytorch.cfg
+++ b/.bumpversion-pytorch.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.2
+current_version = 2.1.0
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.bumpversion-tensorflow.cfg
+++ b/.bumpversion-tensorflow.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.bumpversion-tensorflow.cfg
+++ b/.bumpversion-tensorflow.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.2
+current_version = 2.1.0
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -20,14 +20,14 @@ jobs:
       - name: Checkout repo content
         uses: actions/checkout@v2
       - name: ooil version
-        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.11
         with:
           args: ooil --version
       - name: Assemble docker compose spec
-        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.11
         with:
           args: ooil compose
       - name: Build all images if multiple
-        uses: docker://itisfoundation/ci-service-integration-library:v2.0.9-dev
+        uses: docker://itisfoundation/ci-service-integration-library:v2.0.11
         with:
           args: docker compose build

--- a/.osparc/jupyter-ml-pytorch/metadata.yml
+++ b/.osparc/jupyter-ml-pytorch/metadata.yml
@@ -2,7 +2,7 @@ name: Jupyter ML PyTorch
 thumbnail: https://imgur.com/0ndE7uX.png
 description: "JupyterLab with PyTorch installed. No other scientific tools are provided."
 key: simcore/services/dynamic/jupyter-ml-pytorch
-version: 2.1.0
+version: 2.2.0
 integration-version: "2.0.0"
 type: dynamic
 authors:

--- a/.osparc/jupyter-ml-pytorch/metadata.yml
+++ b/.osparc/jupyter-ml-pytorch/metadata.yml
@@ -1,6 +1,7 @@
 name: Jupyter ML PyTorch
-thumbnail: https://imgur.com/0ndE7uX.png
-description: "JupyterLab with PyTorch installed. No other scientific tools are provided."
+description: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/refs/heads/main/app/full/services/simcore_services_dynamic_jupyter-ml-pytorch.md
+icon: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/icons/s4l/simcore_services_dynamic_jupyter-ml-pytorch.png
+thumbnail: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/thumbnails/s4l/simcore_services_dynamic_jupyter-ml-pytorch.png
 key: simcore/services/dynamic/jupyter-ml-pytorch
 version: 2.2.0
 integration-version: "2.0.0"

--- a/.osparc/jupyter-ml-tensorflow/metadata.yml
+++ b/.osparc/jupyter-ml-tensorflow/metadata.yml
@@ -1,6 +1,7 @@
 name: Jupyter ML Tensorflow
-thumbnail: https://i.imgur.com/iKoFIN0.png
-description: "JupyterLab with Tensorflow installed. No other scientific tools are provided."
+description: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/refs/heads/main/app/full/services/simcore_services_dynamic_jupyter-ml-tensorflow.md
+icon: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/icons/s4l/simcore_services_dynamic_jupyter-ml-tensorflow.png
+thumbnail: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/thumbnails/s4l/simcore_services_dynamic_jupyter-ml-tensorflow.png
 key: simcore/services/dynamic/jupyter-ml-tensorflow
 version: 2.2.0
 integration-version: "2.0.0"

--- a/.osparc/jupyter-ml-tensorflow/metadata.yml
+++ b/.osparc/jupyter-ml-tensorflow/metadata.yml
@@ -2,7 +2,7 @@ name: Jupyter ML Tensorflow
 thumbnail: https://i.imgur.com/iKoFIN0.png
 description: "JupyterLab with Tensorflow installed. No other scientific tools are provided."
 key: simcore/services/dynamic/jupyter-ml-tensorflow
-version: 2.1.0
+version: 2.2.0
 integration-version: "2.0.0"
 type: dynamic
 authors:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ define _bumpversion
 	# upgrades as $(subst $(1),,$@) version, commits and tags
 	@docker run -it --rm -v $(PWD):/ml-lab \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v2.0.9-dev \
+		itisfoundation/ci-service-integration-library:v2.0.11 \
 		sh -c "cd /ml-lab && bump2version --verbose --list --config-file $(1) $(subst $(2),,$@)"
 endef
 
@@ -30,7 +30,7 @@ version-pytorch-patch version-pytorch-minor version-pytorch-major: .bumpversion-
 compose-spec: ## runs ooil to assemble the docker-compose.yml file
 	@docker run -it --rm -v $(PWD):/ml-lab \
 		-u $(shell id -u):$(shell id -g) \
-		itisfoundation/ci-service-integration-library:v2.0.9-dev \
+		itisfoundation/ci-service-integration-library:v2.0.11 \
 		sh -c "cd /ml-lab && ooil compose"
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ SHELL = /bin/sh
 
 export IMAGE_PYTORCH=jupyter-ml-pytorch
 export IMAGE_TENSORFLOW=jupyter-ml-tensorflow
-export TAG_PYTORCH=2.0.2
-export TAG_TENSORFLOW=2.0.2
+export TAG_PYTORCH=2.1.0
+export TAG_TENSORFLOW=2.1.0
 
 define _bumpversion
 	# upgrades as $(subst $(1),,$@) version, commits and tags

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/sh
 
 export IMAGE_PYTORCH=jupyter-ml-pytorch
 export IMAGE_TENSORFLOW=jupyter-ml-tensorflow
-export TAG_PYTORCH=2.1.0
+export TAG_PYTORCH=2.2.0
 export TAG_TENSORFLOW=2.2.0
 
 define _bumpversion

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/sh
 export IMAGE_PYTORCH=jupyter-ml-pytorch
 export IMAGE_TENSORFLOW=jupyter-ml-tensorflow
 export TAG_PYTORCH=2.1.0
-export TAG_TENSORFLOW=2.1.0
+export TAG_TENSORFLOW=2.2.0
 
 define _bumpversion
 	# upgrades as $(subst $(1),,$@) version, commits and tags

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -228,40 +228,20 @@ RUN pip install voila && \
     jupyter serverextension enable voila && \
     jupyter server extension enable voila
 
-USER root
-# installing python via pyenv
+# Install uv tool
+COPY --from=ghcr.io/astral-sh/uv:0.7.6 /uv /uvx /bin/
+ENV UV_HTTP_TIMEOUT=120
 
+# Install Python
 ARG PYTHON_VERSION=3.12.10
-ENV PYENV_ROOT $HOME/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    make \
-    build-essential \
-    libssl-dev \
-    zlib1g-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    wget \
-    curl \
-    llvm \
-    libncurses5-dev \
-    xz-utils \
-    tk-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    libffi-dev \
-    liblzma-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-USER $NB_USER
-RUN git clone https://github.com/pyenv/pyenv.git ${HOME}/.pyenv && \
-    git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
-    pyenv install ${PYTHON_VERSION} && \
-    pyenv virtualenv ${PYTHON_VERSION} lab-venv && \
-    ${HOME}/.pyenv/versions/lab-venv/bin/python --version && \
-    ${HOME}/.pyenv/versions/lab-venv/bin/pip install --upgrade pip ipykernel && \
-    ${HOME}/.pyenv/versions/lab-venv/bin/python -m ipykernel install --user --name kpy312 --display-name "Python (${PYTHON_VERSION})" && \
+ENV UV_PYTHON_INSTALL_DIR="$HOME/.uv-python"
+ENV UV_CACHE_DIR="$HOME/.uv-cache"
+RUN mkdir -p $HOME/.uv-python \
+    && mkdir -p $HOME/.uv-cache \
+    && uv venv $HOME/.venv --python=python${PYTHON_VERSION%.*}
+ENV PATH="$HOME/.venv/bin:$PATH"
+RUN uv pip install --upgrade pip ipykernel && \
+    python -m ipykernel install --user --name kpy312 --display-name "Python (${PYTHON_VERSION})" && \
     echo y | jupyter kernelspec uninstall python3
 
 USER root
@@ -278,4 +258,4 @@ COPY --chown=$NB_UID:$NB_GID README.ipynb ${NOTEBOOK_BASE_DIR}/README.ipynb
 
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-12.8/lib64"
 
-RUN echo 'source /home/${NB_USER}/.pyenv/versions/lab-venv/bin/activate' >> "/home/${NB_USER}/.bashrc"
+RUN echo 'source $HOME/.venv/bin/activate' >> "/home/${NB_USER}/.bashrc"

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu18.04 AS ml-base
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04 AS ml-base
 
 LABEL maintainer="Andrei Neagu <neagu@speag.swiss>"
 
@@ -48,12 +48,20 @@ RUN chmod a+rx /usr/local/bin/fix-permissions
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
 
-# Create NB_USER wtih name jovyan user with UID=1000 and in the 'users' group
+# Create NB_USER with name jovyan user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
 RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     sed -i.bak -e 's/^%admin/#%admin/' /etc/sudoers && \
     sed -i.bak -e 's/^%sudo/#%sudo/' /etc/sudoers && \
-    useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    # Check if the user with UID 1000 already exists
+    if id -u $NB_UID >/dev/null 2>&1; then \
+        # Either modify existing user or create a different UID
+        usermod -l $NB_USER $(id -nu $NB_UID) && \
+        usermod -d /home/$NB_USER -m $NB_USER; \
+    else \
+        # Create the user normally
+        useradd -m -s /bin/bash -N -u $NB_UID $NB_USER; \
+    fi && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER:$NB_GID $CONDA_DIR && \
     chmod g+w /etc/passwd && \
@@ -62,7 +70,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
 
 USER $NB_UID
 WORKDIR $HOME
-ARG PYTHON_VERSION=3.7
+ARG MAMBA_PYTHON_VERSION=3.7
 
 # Setup work directory for backward-compatibility
 RUN mkdir /home/$NB_USER/work && \
@@ -78,7 +86,7 @@ RUN cd /tmp && \
     mamba config --system --set show_channel_urls true && \
     mamba config --system --set channel_priority strict && \
     mamba config --system --set repodata_threads 5 && \
-    mamba install --yes python=$PYTHON_VERSION && \
+    mamba install --yes python=$MAMBA_PYTHON_VERSION && \
     mamba list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     mamba list tini | grep tini | tr -s ' ' | cut -d ' ' -f 1,2 >> $CONDA_DIR/conda-meta/pinned && \
     mamba install --yes \
@@ -121,12 +129,12 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     libxext-dev \
     libxrender1 \
     lmodern \
-    netcat \
-    python-dev \
+    netcat-openbsd \
+    python-dev-is-python3 \
     # ---- nbconvert dependencies ----
     texlive-xetex \
     texlive-fonts-recommended \
-    texlive-generic-recommended \
+    texlive-plain-generic \
     # Optional dependency
     texlive-fonts-extra \
     # ----
@@ -215,14 +223,15 @@ CMD ["start-notebook.sh"]
 ENTRYPOINT [ "/bin/bash", "/docker/run.bash" ]
 
 
-# Install voila parts. This may done higher up in the chain such that the other flavors also have it
+# Install voila parts. This is done higher up in the chain such that the other flavors also have it
 RUN pip install voila && \
     jupyter serverextension enable voila && \
     jupyter server extension enable voila
 
 USER root
 # installing python via pyenv
-ARG PYTHON_VERSION=3.9.12
+
+ARG PYTHON_VERSION=3.12.10
 ENV PYENV_ROOT $HOME/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN apt-get update && \
@@ -252,7 +261,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ${HOME}/.pyenv && \
     pyenv virtualenv ${PYTHON_VERSION} lab-venv && \
     ${HOME}/.pyenv/versions/lab-venv/bin/python --version && \
     ${HOME}/.pyenv/versions/lab-venv/bin/pip install --upgrade pip ipykernel && \
-    ${HOME}/.pyenv/versions/lab-venv/bin/python -m ipykernel install --user --name kpy39 --display-name "Python (${PYTHON_VERSION})" && \
+    ${HOME}/.pyenv/versions/lab-venv/bin/python -m ipykernel install --user --name kpy312 --display-name "Python (${PYTHON_VERSION})" && \
     echo y | jupyter kernelspec uninstall python3
 
 USER root
@@ -267,6 +276,6 @@ ENV DY_SIDECAR_PATH_INPUTS="$HOME/.hidden_inputs" \
 # copy README and CHANGELOG
 COPY --chown=$NB_UID:$NB_GID README.ipynb ${NOTEBOOK_BASE_DIR}/README.ipynb
 
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-11.2/lib64"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-12.8/lib64"
 
 RUN echo 'source /home/${NB_USER}/.pyenv/versions/lab-venv/bin/activate' >> "/home/${NB_USER}/.bashrc"

--- a/jupyter-ml-pytorch/CHANGELOG.md
+++ b/jupyter-ml-pytorch/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.0] - 2025-05-21
+- upgraded ubuntu base to 20.04
+- upgraded CUDA to 12.8
+- upgraded python to 3.12.10
+- upgraded pytorch to latest available version `torch==2.7.0`
+
+## [2.1.0] - 2025-01-24
+- replaced AIRAM with VRAM
+
 ## [2.0.2] - 2022-07-25
 - Bumping up cuda from `11.0` to `11.2`
 

--- a/jupyter-ml-pytorch/Dockerfile
+++ b/jupyter-ml-pytorch/Dockerfile
@@ -9,7 +9,6 @@ COPY --chown=$NB_UID:$NB_GID CHANGELOG.md ${NOTEBOOK_BASE_DIR}/CHANGELOG.md
 # Change to NB_USER, otherwise packages installed below will belong to root
 USER $NB_USER 
 # NOTE: below is the offical way to install pytorch from the docs
-RUN $HOME/.pyenv/versions/lab-venv/bin/pip --no-cache install \
-    -r ${NOTEBOOK_BASE_DIR}/requirements.txt
+RUN uv pip install -r ${NOTEBOOK_BASE_DIR}/requirements.txt
 
 USER root

--- a/jupyter-ml-pytorch/Dockerfile
+++ b/jupyter-ml-pytorch/Dockerfile
@@ -10,7 +10,6 @@ COPY --chown=$NB_UID:$NB_GID CHANGELOG.md ${NOTEBOOK_BASE_DIR}/CHANGELOG.md
 USER $NB_USER 
 # NOTE: below is the offical way to install pytorch from the docs
 RUN $HOME/.pyenv/versions/lab-venv/bin/pip --no-cache install \
-    -r ${NOTEBOOK_BASE_DIR}/requirements.txt \
-    torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+    -r ${NOTEBOOK_BASE_DIR}/requirements.txt
 
 USER root

--- a/jupyter-ml-pytorch/requirements.txt
+++ b/jupyter-ml-pytorch/requirements.txt
@@ -1,4 +1,4 @@
-numpy<2
-torch==1.11.0+cu113
-torchaudio==0.11.0+cu113
-torchvision==0.12.0+cu113
+--index-url https://download.pytorch.org/whl/cu128
+torch==2.7.0
+torchaudio==2.7.0
+torchvision==0.22.0

--- a/jupyter-ml-tensorflow/CHANGELOG.md
+++ b/jupyter-ml-tensorflow/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.0] - 2025-05-21
+- upgraded ubuntu base to 20.04
+- upgraded CUDA to 12.8
+- upgraded python to 3.12.10
+- upgraded tensorflow to latest available version `tensorflow[and-cuda]==2.18.1`
+
+## [2.1.0] - 2025-01-24
+- replaced AIRAM with VRAM
+
 ## [2.0.2] - 2022-07-25
 - Bumping up cuda from `11.0` to `11.2`
   

--- a/jupyter-ml-tensorflow/Dockerfile
+++ b/jupyter-ml-tensorflow/Dockerfile
@@ -8,8 +8,7 @@ COPY --chown=$NB_UID:$NB_GID CHANGELOG.md ${NOTEBOOK_BASE_DIR}/CHANGELOG.md
 # Change to NB_USER, otherwise packages installed below will belong to root
 USER $NB_USER
 ## TODO: ensure is up-to-date before copying it
-RUN $HOME/.pyenv/versions/lab-venv/bin/pip --no-cache install \
-    -r ${NOTEBOOK_BASE_DIR}/requirements.txt
+RUN uv pip install -r ${NOTEBOOK_BASE_DIR}/requirements.txt
 
 USER root
 ENV TF_FORCE_GPU_ALLOW_GROWTH=true

--- a/jupyter-ml-tensorflow/requirements.txt
+++ b/jupyter-ml-tensorflow/requirements.txt
@@ -1,2 +1,1 @@
-numpy<2
-tensorflow-gpu==2.9.0
+tensorflow[and-cuda]==2.18.1


### PR DESCRIPTION
- upgraded ubuntu base to 20.04
- upgraded CUDA to 12.8
- upgraded python to 3.12.10
- upgrades both tensorflow and pytorch to latest available versions
- thumbnail, icon and description are now pulled form ZMT's GitHub assets repository
- using uv instead of pyenv

Related issues:
- https://github.com/ITISFoundation/private-issues/issues/78